### PR TITLE
Update `.gitignore` and Gradle wrapper files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ build/
 */build/
 */.gradle/
 .gradletasknamecache
-!gradle-wrapper.jar
+gradle/wrapper/gradle-wrapper.jar
 
 # Eclipse
 **/bin/
@@ -57,3 +57,4 @@ changelog.txt
 .directory
 Thumbs.db
 *.stackdump
+gradle/wrapper/gradle-wrapper.properties

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -206,7 +205,7 @@ fi
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
-#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.


### PR DESCRIPTION
- Adjust `.gitignore` to include `gradle/wrapper/gradle-wrapper.jar` and `gradle/wrapper/gradle-wrapper.properties`.
- Fix newline formatting issue in `.gitignore`.
- Correct formatting in `gradlew` script to resolve improper line break and minor comment adjustment.