### PR TITLE
Initialize ContentCraft mod structure and data generation framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ changelog.txt
 Thumbs.db
 *.stackdump
 gradle/wrapper/gradle-wrapper.properties
+/run/
+/src/generated/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ build/
 */build/
 */.gradle/
 .gradletasknamecache
-!gradle-wrapper.jar
+gradle/wrapper/gradle-wrapper.jar
 
 # Eclipse
 **/bin/
@@ -57,3 +57,4 @@ changelog.txt
 .directory
 Thumbs.db
 *.stackdump
+gradle/wrapper/gradle-wrapper.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ loader_version_range=[1,)
 
 # The unique mod identifier for the mod. Must be lowercase in English locale. Must fit the regex [a-z][a-z0-9_]{1,63}
 # Must match the String constant located in the main mod class annotated with @Mod.
-mod_id=contentcraft
+mod_id=gl_content_craft
 # The human-readable display name for the mod.
 mod_name=ContentCraft
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -206,7 +205,7 @@ fi
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
-#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.

--- a/src/main/java/xyz/glowstonelabs/contentcraft/Config.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/Config.java
@@ -1,9 +1,5 @@
 package xyz.glowstonelabs.contentcraft;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
@@ -12,9 +8,13 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 // An example config class. This is not required, but it's a good idea to have one to keep your config organized.
 // Demonstrates how to use Neo's config APIs
-@EventBusSubscriber(modid = ContentCraft.MODID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = ContentCraft.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public class Config
 {
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();

--- a/src/main/java/xyz/glowstonelabs/contentcraft/ContentCraft.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/ContentCraft.java
@@ -1,22 +1,20 @@
+/*
+ * Glowstone Labs - ContentCraft - ContentCraft Mod (Entrypoint)
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
 package xyz.glowstonelabs.contentcraft;
 
-import org.slf4j.Logger;
-
 import com.mojang.logging.LogUtils;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.food.FoodProperties;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.material.MapColor;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -29,49 +27,56 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
-import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredHolder;
-import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import org.slf4j.Logger;
 
-// The value here should match an entry in the META-INF/neoforge.mods.toml file
-@Mod(ContentCraft.MODID)
+
+/**
+ * Main mod class for ContentCraft - A Minecraft mod adding new content and features
+ * This class handles mod initialization, registry setup, and event management
+ */
+@Mod(ContentCraft.MOD_ID)
 public class ContentCraft
 {
-    // Define mod id in a common place for everything to reference
-    public static final String MODID = "contentcraft";
-    // Directly reference a slf4j logger
+    /**
+     * Mod identifier used for registry names and logging
+     */
+    public static final String MOD_ID = "gl_content_craft";
+
+    /**
+     * Central logger for the mod
+     */
     private static final Logger LOGGER = LogUtils.getLogger();
-    // Create a Deferred Register to hold Blocks which will all be registered under the "contentcraft" namespace
-    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
-    // Create a Deferred Register to hold Items which will all be registered under the "contentcraft" namespace
-    public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
-    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the "contentcraft" namespace
-    public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
 
-    // Creates a new Block with the id "contentcraft:example_block", combining the namespace and path
-    public static final DeferredBlock<Block> EXAMPLE_BLOCK = BLOCKS.registerSimpleBlock("example_block", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    // Creates a new BlockItem with the id "contentcraft:example_block", combining the namespace and path
-    public static final DeferredItem<BlockItem> EXAMPLE_BLOCK_ITEM = ITEMS.registerSimpleBlockItem("example_block", EXAMPLE_BLOCK);
+    /**
+     * Registry for mod blocks
+     */
+    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
 
-    // Creates a new food item with the id "contentcraft:example_id", nutrition 1 and saturation 2
-    public static final DeferredItem<Item> EXAMPLE_ITEM = ITEMS.registerSimpleItem("example_item", new Item.Properties().food(new FoodProperties.Builder()
-            .alwaysEdible().nutrition(1).saturationModifier(2f).build()));
+    /**
+     * Registry for mod items
+     */
+    public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    // Creates a creative tab with the id "contentcraft:example_tab" for the example item, that is placed after the combat tab
-    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> EXAMPLE_TAB = CREATIVE_MODE_TABS.register("example_tab", () -> CreativeModeTab.builder()
-            .title(Component.translatable("itemGroup.contentcraft")) //The language key for the title of your CreativeModeTab
-            .withTabsBefore(CreativeModeTabs.COMBAT)
-            .icon(() -> EXAMPLE_ITEM.get().getDefaultInstance())
-            .displayItems((parameters, output) -> {
-                output.accept(EXAMPLE_ITEM.get()); // Add the example item to the tab. For your own tabs, this method is preferred over the event
-            }).build());
+    /**
+     * Registry for creative mode tabs
+     */
+    public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MOD_ID);
 
-    // The constructor for the mod class is the first code that is run when your mod is loaded.
-    // FML will recognize some parameter types like IEventBus or ModContainer and pass them in automatically.
+    /** Creative tab for mod blocks and items */
+    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> BLOCKS_TAB = CREATIVE_MODE_TABS.register(
+            "block_creative_tab",
+            () -> CreativeModeTab.builder()
+                    .title(Component.translatable("itemGroup.contentCraft.blocks"))
+                    .withTabsBefore(CreativeModeTabs.COMBAT)
+                    .icon(Items.DIAMOND_SWORD::getDefaultInstance)
+                    .displayItems((parameters, output) -> output.accept(Items.DIAMOND_SWORD)).build()
+    );
+
+    // Entry point for the mod. Called by NeoForge during mod loading.
     public ContentCraft(IEventBus modEventBus, ModContainer modContainer)
     {
-        // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);
 
         // Register the Deferred Register to the mod event bus so blocks get registered
@@ -81,9 +86,6 @@ public class ContentCraft
         // Register the Deferred Register to the mod event bus so tabs get registered
         CREATIVE_MODE_TABS.register(modEventBus);
 
-        // Register ourselves for server and other game events we are interested in.
-        // Note that this is necessary if and only if we want *this* class (ContentCraft) to respond directly to events.
-        // Do not add this line if there are no @SubscribeEvent-annotated functions in this class, like onServerStarting() below.
         NeoForge.EVENT_BUS.register(this);
 
         // Register the item to a creative tab
@@ -93,24 +95,22 @@ public class ContentCraft
         modContainer.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
     }
 
-    private void commonSetup(final FMLCommonSetupEvent event)
-    {
-        // Some common setup code
-        LOGGER.info("HELLO FROM COMMON SETUP");
-
-        if (Config.logDirtBlock)
-            LOGGER.info("DIRT BLOCK >> {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
-
-        LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
-
-        Config.items.forEach((item) -> LOGGER.info("ITEM >> {}", item.toString()));
+    /**
+     * Handles common setup tasks for both client and server
+     * @param event The common setup event
+     */
+    private void commonSetup(final FMLCommonSetupEvent event) {
+        if (Config.logDirtBlock) {
+            LOGGER.info("Registered blocks: {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
+        }
     }
 
-    // Add the example block item to the building blocks tab
+    // Add items to vanilla creative tabs
     private void addCreative(BuildCreativeModeTabContentsEvent event)
     {
-        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS)
-            event.accept(EXAMPLE_BLOCK_ITEM);
+        //Register to vanilla creative tabs example
+//        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS)
+//            event.accept(EXAMPLE_BLOCK_ITEM);
     }
 
     // You can use SubscribeEvent and let the Event Bus discover methods to call
@@ -121,16 +121,14 @@ public class ContentCraft
         LOGGER.info("HELLO from server starting");
     }
 
-    // You can use EventBusSubscriber to automatically register all static methods in the class annotated with @SubscribeEvent
-    @EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
-    public static class ClientModEvents
-    {
+    /**
+     * Handles client side only events and initialization
+     */
+    @EventBusSubscriber(modid = MOD_ID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+    public static class ClientModEvents {
         @SubscribeEvent
-        public static void onClientSetup(FMLClientSetupEvent event)
-        {
-            // Some client setup code
-            LOGGER.info("HELLO FROM CLIENT SETUP");
-            LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());
+        public static void onClientSetup(FMLClientSetupEvent event) {
+            LOGGER.info("Initializing client for player: {}", Minecraft.getInstance().getUser().getName());
         }
     }
 }

--- a/src/main/java/xyz/glowstonelabs/contentcraft/block/ModBlocksInit.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/block/ModBlocksInit.java
@@ -1,0 +1,7 @@
+package xyz.glowstonelabs.contentcraft.block;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+public class ModBlocksInit {
+    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(ContentCraft.MOD_ID);
+}

--- a/src/main/java/xyz/glowstonelabs/contentcraft/datagen/DataGenerator.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/datagen/DataGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Glowstone Labs - ContentCraft - DataGenerator
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
+package xyz.glowstonelabs.contentcraft.datagen;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.loot.LootTableProvider;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.common.data.BlockTagsProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Main data generation class for the ContentCraft mod.
+ * Handles registration of various data providers for recipes, loot tables, tags, and models.
+ * This class is automatically subscribed to mod events via EventBusSubscriber.
+ */
+@EventBusSubscriber(modid = ContentCraft.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+public class DataGenerator {
+    /**
+     * Main data generation method that registers all data providers.
+     * Called automatically during data generation phase.
+     *
+     * @param event The GatherDataEvent containing necessary context for data generation
+     */
+    @SubscribeEvent
+    public static void gatherData(GatherDataEvent event) {
+        net.minecraft.data.DataGenerator generator = event.getGenerator();
+        PackOutput packOutput = generator.getPackOutput();
+        ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
+        CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+
+        // Register recipe generation provider
+        generator.addProvider(event.includeServer(), new ModRecipeProvider(packOutput, lookupProvider));
+
+        // Register loot table generation provider for blocks
+        generator.addProvider(event.includeServer(), new LootTableProvider(
+                packOutput,
+                Collections.emptySet(),
+                List.of(new LootTableProvider.SubProviderEntry(ModBlockLootTableProvider::new, LootContextParamSets.BLOCK)), lookupProvider)
+        );
+
+        // Create block tags provider for use in item tags
+        BlockTagsProvider blockTagsProvider = new ModBlockTagProvider(packOutput, lookupProvider, ContentCraft.MOD_ID, existingFileHelper);
+
+        // Register block tags provider
+        generator.addProvider(event.includeServer(), blockTagsProvider);
+
+        // Register item tags provider (depends on block tags)
+        generator.addProvider(event.includeServer(), new ModItemTagProvider(packOutput, lookupProvider, blockTagsProvider.contentsGetter(), existingFileHelper));
+
+        // Register block states and models provider
+        generator.addProvider(event.includeClient(), new ModBlockStateProvider(packOutput, existingFileHelper));
+
+        // Register item models provider
+        generator.addProvider(event.includeClient(), new ModItemModelProvider(packOutput, existingFileHelper));
+    }
+}

--- a/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModBlockLootTableProvider.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModBlockLootTableProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Glowstone Labs - ContentCraft - LootTableProvider
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
+package xyz.glowstonelabs.contentcraft.datagen;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.loot.BlockLootSubProvider;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+import org.jetbrains.annotations.NotNull;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+import java.util.Set;
+
+/**
+ * Provider class for generating loot tables for ContentCraft mod blocks.
+ * Extends Minecraft's BlockLootSubProvider to handle custom block drops.
+ */
+public class ModBlockLootTableProvider extends BlockLootSubProvider {
+    /** Set of items that are resistant to explosions when dropped */
+    private static final Set<Item> EXPLOSION_RESISTANT = Set.of();
+
+    /**
+     * Constructs a new ModBlockLootTableProvider.
+     *
+     * @param registries The registry provider for looking up game objects
+     */
+    protected ModBlockLootTableProvider(HolderLookup.Provider registries) {
+        super(EXPLOSION_RESISTANT, FeatureFlags.REGISTRY.allFlags(), registries);
+    }
+
+    /**
+     * Generates loot tables for all ContentCraft mod blocks.
+     * Called during data generation to create block loot table JSON files.
+     */
+    @Override
+    protected void generate() {
+
+    }
+
+    /**
+     * Gets all registered blocks from the ContentCraft mod.
+     *
+     * @return An Iterable of all known mod blocks
+     */
+    @Override
+    protected @NotNull Iterable<Block> getKnownBlocks() {
+        return ContentCraft.BLOCKS.getEntries().stream().map(Holder::value)::iterator;
+    }
+
+    /**
+     * Creates a loot table builder for ore blocks that drop multiple items.
+     * Includes fortune enchantment bonus and supports silk touch.
+     *
+     * @param block The block to create drops for
+     * @param drop The item to be dropped
+     * @param min Minimum number of items to drop
+     * @param max Maximum number of items to drop
+     * @return A LootTable.Builder configured with the specified drops
+     */
+    protected LootTable.Builder createMultiOreDrops(Block block, Item drop, int min, int max ) {
+        HolderLookup.RegistryLookup<Enchantment> registrylookup = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
+        return this.createSilkTouchDispatchTable(block, this.applyExplosionDecay(block, LootItem.lootTableItem(drop)
+                        .apply(SetItemCountFunction.setCount(UniformGenerator.between(min, max)))
+                        .apply(ApplyBonusCount.addOreBonusCount(registrylookup.getOrThrow(Enchantments.FORTUNE)))));
+    }
+}

--- a/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModBlockStateProvider.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModBlockStateProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Glowstone Labs - ContentCraft - BlockStateProvider
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
+package xyz.glowstonelabs.contentcraft.datagen;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+/**
+ * Provider class for generating block states and models for ContentCraft mod.
+ * Handles the automatic generation of block states, models and item models
+ * for registered blocks in the mod.
+ */
+public class ModBlockStateProvider extends BlockStateProvider {
+    /**
+     * Constructor for ModBlockStateProvider.
+     *
+     * @param output       The PackOutput instance for generating data
+     * @param exFileHelper Helper for accessing existing files in data/resource packs
+     */
+    public ModBlockStateProvider(PackOutput output, ExistingFileHelper exFileHelper) {
+        super(output, ContentCraft.MOD_ID, exFileHelper);
+    }
+
+    /**
+     * Main method for registering block states and models.
+     * Called during data generation to create block states and models for mod blocks.
+     */
+    @Override
+    protected void registerStatesAndModels() {
+        // Register block states and models here
+    }
+
+    /**
+     * Helper method to generate both block and item models for a block.
+     *
+     * @param deferredBlock The block to generate models for
+     * @param name          The name of the block (used for model generation)
+     */
+    protected void blockWithItem(DeferredBlock<Block> deferredBlock, String name) {
+        // Generate a simple block model and corresponding item model using the cube all texture
+        simpleBlockWithItem(deferredBlock.get(), cubeAll(deferredBlock.get()));
+    }
+}

--- a/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModBlockTagProvider.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModBlockTagProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Glowstone Labs - ContentCraft - BlockTagProvider
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
+package xyz.glowstonelabs.contentcraft.datagen;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.tags.BlockTags;
+import net.neoforged.neoforge.common.data.BlockTagsProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Provides block tag data generation functionality for the ContentCraft mod.
+ * This class is responsible for defining which blocks belong to which tags,
+ * particularly focusing on tool requirements and mining tiers.
+ */
+public class ModBlockTagProvider extends BlockTagsProvider {
+    /**
+     * Constructs a new ModBlockTagProvider.
+     *
+     * @param output The PackOutput instance for data generation
+     * @param lookupProvider Provider for registry lookups
+     * @param modId The mod ID (automatically set to ContentCraft.MOD_ID)
+     * @param existingFileHelper Helper for checking existing files
+     */
+    public ModBlockTagProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, String modId, @Nullable ExistingFileHelper existingFileHelper) {
+        super(output, lookupProvider, ContentCraft.MOD_ID, existingFileHelper);
+    }
+
+    /**
+     * Adds block tags for the ContentCraft mod.
+     * This method defines various mining requirements for blocks including:
+     * - Tool type requirements (pickaxe, axe, hoe, shovel)
+     * - Tool tier requirements (stone, iron, diamond)
+     *
+     * @param provider The registry lookup provider
+     */
+    @Override
+    protected void addTags(HolderLookup.@NotNull Provider provider) {
+        // Blocks that require a pickaxe to mine
+        this.tag(BlockTags.MINEABLE_WITH_PICKAXE);
+        // Blocks that require a shovel to mine
+        this.tag(BlockTags.MINEABLE_WITH_AXE);
+        // Blocks that require a hoe to mine
+        this.tag(BlockTags.MINEABLE_WITH_HOE);
+        // Blocks that require a shovel to mine
+        this.tag(BlockTags.MINEABLE_WITH_SHOVEL);
+        //Blocks that need tool tier stone+
+        this.tag(BlockTags.NEEDS_STONE_TOOL);
+        //Blocks that need tool tier iron+
+        this.tag(BlockTags.NEEDS_IRON_TOOL);
+        //Blocks that need tool tier diamond+
+        this.tag(BlockTags.NEEDS_DIAMOND_TOOL);
+    }
+}

--- a/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModItemModelProvider.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModItemModelProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Glowstone Labs - ContentCraft - ItemModelProvider
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
+package xyz.glowstonelabs.contentcraft.datagen;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.item.Item;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.registries.DeferredItem;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+/**
+ * Provides item model generation functionality for ContentCraft mod items.
+ * This class handles the automatic generation of JSON model files for items
+ * during the data generation phase of mod building.
+ */
+public class ModItemModelProvider extends ItemModelProvider {
+    /**
+     * Creates a new ModItemModelProvider instance.
+     *
+     * @param output The PackOutput instance for writing generated files
+     * @param existingFileHelper Helper utility for accessing existing files
+     */
+    public ModItemModelProvider(PackOutput output, ExistingFileHelper existingFileHelper) {
+        super(output, ContentCraft.MOD_ID, existingFileHelper);
+    }
+
+    /**
+     * Registers all item models for the mod.
+     * This method is called during data generation to create model files
+     * for each item that needs a model.
+     */
+    @Override
+    protected void registerModels() {
+
+    }
+
+    /**
+     * Registers a basic item model for the given deferred item.
+     *
+     * @param deferredItem The DeferredItem to generate a basic item model for
+     */
+    protected void item(DeferredItem<Item> deferredItem) {
+        basicItem(deferredItem.get());
+    }
+}

--- a/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModItemTagProvider.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModItemTagProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Glowstone Labs - ContentCraft - ItemTagsProvider
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
+package xyz.glowstonelabs.contentcraft.datagen;
+
+/**
+ * Provider for generating item tags for ContentCraft mod.
+ * Handles the data generation of item tags which are used for item categorization and recipe requirements.
+ */
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.ItemTagsProvider;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ModItemTagProvider extends ItemTagsProvider {
+
+    /**
+     * Constructs a new ModItemTagProvider.
+     *
+     * @param output             The pack output directory
+     * @param lookupProvider     Provider for registry lookups
+     * @param blockTags          Future containing block tags
+     * @param existingFileHelper Helper for checking existing files
+     */
+    public ModItemTagProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider,
+                              CompletableFuture<TagLookup<Block>> blockTags, @Nullable ExistingFileHelper existingFileHelper) {
+        super(output, lookupProvider, blockTags, ContentCraft.MOD_ID, existingFileHelper);
+    }
+
+    /**
+     * Adds item tags to the data generation.
+     * Called during data generation to define item tags for the mod.
+     *
+     * @param provider The registry lookup provider
+     */
+    @Override
+    protected void addTags(HolderLookup.@NotNull Provider provider) {
+
+    }
+}

--- a/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModRecipeProvider.java
+++ b/src/main/java/xyz/glowstonelabs/contentcraft/datagen/ModRecipeProvider.java
@@ -1,0 +1,97 @@
+/*
+ * Glowstone Labs - ContentCraft - RecipeProvider
+ * 2025 Glowstone Labs
+ * changelog:
+ *  - initial implementation - CodeRandomMc
+ */
+package xyz.glowstonelabs.contentcraft.datagen;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.data.recipes.SimpleCookingRecipeBuilder;
+import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.level.ItemLike;
+import net.neoforged.neoforge.common.conditions.IConditionBuilder;
+import org.jetbrains.annotations.NotNull;
+import xyz.glowstonelabs.contentcraft.ContentCraft;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Provider class for generating ContentCraft mod recipes during data generation.
+ * Extends Minecraft's RecipeProvider and implements IConditionBuilder for conditional recipes.
+ */
+public class ModRecipeProvider extends RecipeProvider implements IConditionBuilder {
+    public ModRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+        super(output, registries);
+    }
+
+    /**
+     * Generates all recipes for the ContentCraft mod.
+     * This method is called during data generation to create recipe JSON files.
+     *
+     * @param recipeOutput The recipe output consumer to register recipes
+     */
+    @Override
+    protected void buildRecipes(@NotNull RecipeOutput recipeOutput) {
+        
+    }
+
+
+    /**
+     * Registers smelting recipes for ore processing.
+     *
+     * @param recipeOutput The recipe output consumer to register recipes
+     * @param ingredients  List of input ingredients that can be smelted
+     * @param category     Recipe category the smelting belongs to
+     * @param result       The resulting item from smelting
+     * @param experience   Amount of experience granted when smelting completes
+     * @param cookingTime  Time in ticks required to complete smelting
+     * @param group        Recipe group name for recipe book organization
+     */
+    protected static void oreSmelting(RecipeOutput recipeOutput, List<ItemLike> ingredients, RecipeCategory category, ItemLike result, float experience, int cookingTime, String group) {
+        oreCooking(recipeOutput, RecipeSerializer.SMELTING_RECIPE, SmeltingRecipe::new, ingredients, category, result, experience, cookingTime, group, "_from_smelting");
+    }
+
+    /**
+     * Registers blast furnace recipes for ore processing.
+     *
+     * @param recipeOutput The recipe output consumer to register recipes
+     * @param ingredients  List of input ingredients that can be blasted
+     * @param category     Recipe category the blasting belongs to
+     * @param result       The resulting item from blasting
+     * @param experience   Amount of experience granted when blasting completes
+     * @param cookingTime  Time in ticks required to complete blasting
+     * @param group        Recipe group name for recipe book organization
+     */
+    protected static void oreBlasting(RecipeOutput recipeOutput, List<ItemLike> ingredients, RecipeCategory category, ItemLike result, float experience, int cookingTime, String group) {
+        oreCooking(recipeOutput, RecipeSerializer.BLASTING_RECIPE, BlastingRecipe::new, ingredients, category, result, experience, cookingTime, group, "_from_blasting");
+    }
+
+    /**
+     * Generic method for registering cooking-type recipes (smelting, blasting, etc).
+     * Creates individual recipes for each input ingredient resulting in the specified output.
+     *
+     * @param recipeOutput  The recipe output consumer to register recipes
+     * @param serializer    The recipe serializer for the specific cooking type
+     * @param recipeFactory Factory method for creating the specific recipe type
+     * @param ingredients   List of input ingredients that can be cooked
+     * @param category      Recipe category the cooking belongs to
+     * @param result        The resulting item from cooking
+     * @param experience    Amount of experience granted when cooking completes
+     * @param cookingTime   Time in ticks required to complete cooking
+     * @param group         Recipe group name for recipe book organization
+     * @param suffix        Suffix to append to recipe names for this cooking type
+     * @param <T>           The specific type of cooking recipe being created
+     */
+    protected static <T extends AbstractCookingRecipe> void oreCooking(RecipeOutput recipeOutput, RecipeSerializer<T> serializer, AbstractCookingRecipe.Factory<T> recipeFactory, List<ItemLike> ingredients, RecipeCategory category, ItemLike result, float experience, int cookingTime, String group, String suffix) {
+        for(ItemLike itemlike : ingredients) {
+            SimpleCookingRecipeBuilder.generic(Ingredient.of(new ItemLike[]{itemlike}), category, result, experience, cookingTime, serializer, recipeFactory).group(group).unlockedBy(getHasName(itemlike), has(itemlike)).save(recipeOutput, ContentCraft.MOD_ID + ":" + getItemName(result) + suffix + "_" + getItemName(itemlike));
+        }
+
+    }
+}

--- a/src/main/resources/assets/contentcraft/lang/en_us.json
+++ b/src/main/resources/assets/contentcraft/lang/en_us.json
@@ -1,5 +1,3 @@
 {
-  "itemGroup.contentcraft": "Example Mod Tab",
-  "block.contentcraft.example_block": "Example Block",
-  "item.contentcraft.example_item": "Example Item"
+  "itemGroup.contentCraft.blocks": "ContentCraft Blocks"
 }


### PR DESCRIPTION
Initialize ContentCraft mod structure and data generation framework

- Implement initial mod classes, including `ContentCraft` (main entry point), `Config`, and block/item registries.
- Add data generation providers (`ModRecipeProvider`, `ModBlockStateProvider`, `ModItemModelProvider`, `ModBlockTagProvider`, `ModItemTagProvider`) for recipes, models, tags, and loot tables.
- Set up creative tabs and default assets.
- Update `gradle.properties` and other meta files for proper mod identification (`mod_id`, `mod_name`).
- Remove example content and adjust language file.